### PR TITLE
fix: auth error(#1)

### DIFF
--- a/src/main/java/com/ktb/ktb_community/common/Security/CookieUtil.java
+++ b/src/main/java/com/ktb/ktb_community/common/Security/CookieUtil.java
@@ -14,7 +14,7 @@ public class CookieUtil {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .path("/api/auth/refresh")
+                .path("/api/auth")
                 .maxAge(refreshTokenValidityInMs)
                 .sameSite("Lax")
                 .build();

--- a/src/main/java/com/ktb/ktb_community/controller/AuthController.java
+++ b/src/main/java/com/ktb/ktb_community/controller/AuthController.java
@@ -55,11 +55,15 @@ public class AuthController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> logout(Principal principal) {
+    public ResponseEntity<Void> logout(
+            Principal principal,
+            @CookieValue("refreshToken") String refreshToken
+    ) {
 
-        String userEmail = principal.getName();
+        if(principal != null) {
+            authService.logout(refreshToken);
+        }
 
-        authService.logout(userEmail);
         ResponseCookie clearCookie = cookieUtil.clearRefreshTokenCookie();
 
         return ResponseEntity.noContent()

--- a/src/main/java/com/ktb/ktb_community/service/AuthService.java
+++ b/src/main/java/com/ktb/ktb_community/service/AuthService.java
@@ -27,6 +27,8 @@ public class AuthService {
     //RT redis 에 저장
     public LoginResponseDto login(LoginRequestDto loginRequest) {
 
+        //이미 로그인 된 경우 처리 로직 필요
+
         User user = userRepository.findByEmail(loginRequest.getEmail())
                 .orElseThrow(() -> new NoPermissionException("user", "email not found"));
 


### PR DESCRIPTION
## 📄 Summary
> 로그인 쿠키 설정 문제 및 로그아웃 권한 없음 문제를 해결했습니다.

## 🙋🏻 More
- 로그인 쿠키 설정을 수정하였습니다. 
    - path 설정을 변경하여, auth 관련 서비스에서 모두 사용할 수 있도록 설정하였습니다.
    - https 환경에서만 사용하도록 secure 설정을 적용하였습니다.
- 로그아웃 권한 없음 문제를 해결했습니다.
    - 쿠키에서 refreshToken을 추출하여 redis에서 정상적으로 삭제되도록 수정하였습니다.
    - redis에 토큰이 없더라도 사용자 경험을 위해 클라이언트 쿠키를 무효화하도록 로직을 수정하였습니다.


## ✨issue
> this closes issue #1 